### PR TITLE
Adjust formatting of last updated date

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,7 @@ const App: React.FC = () => {
   }
 
   const lastUpdateObject = new Date(leaderboardData.metadata.datetime);
-  const lastUpdateString = lastUpdateObject.toLocaleString();
+  const lastUpdateString = lastUpdateObject.toLocaleString([], {dateStyle: 'medium', timeStyle: 'long'});
   console.log(lastUpdateString)
 
   return (


### PR DESCRIPTION
This changes the formatting of the “last updated” timestamp at the bottom of the page for clarity:

* The date style is changed to medium so the month name is used instead of the month number, which disambiguates between month/day and day/month formats
* The time style is changed to long so the timezone is included. Viewers may otherwise not expect the timestamp to be in their local timezone.